### PR TITLE
adding FromSetting for declarative spider param defaults

### DIFF
--- a/scrapy_spider_metadata/_params.py
+++ b/scrapy_spider_metadata/_params.py
@@ -4,6 +4,7 @@ from typing import Any, Generic, TypeVar
 from pydantic import BaseModel, ValidationError
 
 from ._utils import get_generic_param, normalize_param_schema
+from .defaults import FromSetting
 
 ParamSpecT = TypeVar("ParamSpecT", bound=BaseModel)
 logger = getLogger(__name__)
@@ -29,6 +30,43 @@ class Args(Generic[ParamSpecT]):
             logger.error(f"Spider parameter validation failed: {e}")
             raise
         super().__init__(*args, **kwargs)
+
+    def _set_crawler(self, crawler):
+        super()._set_crawler(crawler)
+
+        if not hasattr(self, "args") or self.args is None:
+            return
+
+        param_model = get_generic_param(self.__class__, Args)
+        assert param_model is not None
+        assert issubclass(param_model, BaseModel)
+
+        # compat Pydantic v1/v2
+        if hasattr(self.args, "model_dump"):
+            data = self.args.model_dump(exclude_unset=True)
+        else:
+            data = self.args.dict(exclude_unset=True)
+
+        fields = getattr(param_model, "model_fields", None) or getattr(
+            param_model, "__fields__", {}
+        )
+
+        for field_name, field in fields.items():
+            default_val = getattr(field, "default", None)
+            if field_name in data and data[field_name] is not None:
+                continue
+            if isinstance(default_val, FromSetting):
+                getter_name = default_val.getter or "get"
+                getter = getattr(crawler.settings, getter_name, crawler.settings.get)
+                value = getter(default_val.name, default_val.default)
+                if value is not None:
+                    data[field_name] = value
+
+        try:
+            self.args = param_model(**data)
+        except ValidationError as e:
+            logger.error(f"Spider parameter validation failed: {e}")
+            raise
 
     @classmethod
     def get_param_schema(cls, normalize: bool = False) -> dict[Any, Any]:

--- a/scrapy_spider_metadata/_params.py
+++ b/scrapy_spider_metadata/_params.py
@@ -1,10 +1,13 @@
 from logging import getLogger
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from pydantic import BaseModel, ValidationError
 
 from ._utils import get_generic_param, normalize_param_schema
 from .defaults import FromSetting
+
+if TYPE_CHECKING:
+    from scrapy.crawler import Crawler
 
 ParamSpecT = TypeVar("ParamSpecT", bound=BaseModel)
 logger = getLogger(__name__)
@@ -31,21 +34,22 @@ class Args(Generic[ParamSpecT]):
             raise
         super().__init__(*args, **kwargs)
 
-    def _set_crawler(self, crawler):
-        super()._set_crawler(crawler)
+    @classmethod
+    def from_crawler(cls, crawler: "Crawler", *args: Any, **kwargs: Any) -> "Args[ParamSpecT]":
+        spider = cast("Args[ParamSpecT]", cast("Any", super()).from_crawler(crawler, *args, **kwargs))
 
-        if not hasattr(self, "args") or self.args is None:
-            return
+        if not hasattr(spider, "args") or spider.args is None:
+            return spider
 
-        param_model = get_generic_param(self.__class__, Args)
+        param_model = get_generic_param(cls, Args)
         assert param_model is not None
         assert issubclass(param_model, BaseModel)
 
         # compat Pydantic v1/v2
-        if hasattr(self.args, "model_dump"):
-            data = self.args.model_dump(exclude_unset=True)
+        if hasattr(spider.args, "model_dump"):
+            data = spider.args.model_dump(exclude_unset=True)
         else:
-            data = self.args.dict(exclude_unset=True)
+            data = spider.args.dict(exclude_unset=True)
 
         fields = getattr(param_model, "model_fields", None) or getattr(
             param_model, "__fields__", {}
@@ -63,10 +67,12 @@ class Args(Generic[ParamSpecT]):
                     data[field_name] = value
 
         try:
-            self.args = param_model(**data)
+            spider.args = cast("ParamSpecT", param_model(**data))
         except ValidationError as e:
             logger.error(f"Spider parameter validation failed: {e}")
             raise
+
+        return spider
 
     @classmethod
     def get_param_schema(cls, normalize: bool = False) -> dict[Any, Any]:

--- a/scrapy_spider_metadata/defaults.py
+++ b/scrapy_spider_metadata/defaults.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class FromSetting:
+    name: str
+    default: Any = None
+    getter: Literal["get", "getint", "getbool", "getfloat"] = "get"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+
+os.environ.setdefault(
+    "TWISTED_REACTOR",
+    "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+)
+
+try:
+    from twisted.internet import asyncioreactor
+    asyncioreactor.install()
+except Exception:
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,3 @@
-import os
+from scrapy.utils.reactor import install_reactor
 
-os.environ.setdefault(
-    "TWISTED_REACTOR",
-    "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
-)
-
-try:
-    from twisted.internet import asyncioreactor
-    asyncioreactor.install()
-except Exception:
-    pass
+install_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")

--- a/tests/test_fromsetting.py
+++ b/tests/test_fromsetting.py
@@ -1,14 +1,15 @@
-import pytest
-from scrapy.utils.test import get_crawler
+from typing import Any
+
 from pydantic import BaseModel
 from scrapy import Spider
+from scrapy.utils.test import get_crawler
 
-from scrapy_spider_metadata.defaults import FromSetting
 from scrapy_spider_metadata._params import Args
+from scrapy_spider_metadata.defaults import FromSetting
 
 
 class Params(BaseModel):
-    pages: int = FromSetting("MAX_PAGES_SETTING", default=5, getter="getint")
+    pages: Any = FromSetting("MAX_PAGES_SETTING", default=5, getter="getint")
     lang: str = "en"
 
 
@@ -18,22 +19,19 @@ class S(Args[Params], Spider):
 
 def test_fromsetting_reads_setting():
     crawler = get_crawler(S, settings_dict={"MAX_PAGES_SETTING": 10})
-    s = S()
-    s._set_crawler(crawler)
+    s = S.from_crawler(crawler)
     assert s.args.pages == 10
     assert s.args.lang == "en"
 
 
 def test_fromsetting_uses_default_when_missing():
     crawler = get_crawler(S, settings_dict={})
-    s = S()
-    s._set_crawler(crawler)
+    s = S.from_crawler(crawler)
     assert s.args.pages == 5
     assert s.args.lang == "en"
 
 
 def test_cli_overrides_everything():
     crawler = get_crawler(S, settings_dict={"MAX_PAGES_SETTING": 10})
-    s = S(pages=99)
-    s._set_crawler(crawler)
+    s = S.from_crawler(crawler, pages=99)
     assert s.args.pages == 99

--- a/tests/test_fromsetting.py
+++ b/tests/test_fromsetting.py
@@ -1,0 +1,39 @@
+import pytest
+from scrapy.utils.test import get_crawler
+from pydantic import BaseModel
+from scrapy import Spider
+
+from scrapy_spider_metadata.defaults import FromSetting
+from scrapy_spider_metadata._params import Args
+
+
+class Params(BaseModel):
+    pages: int = FromSetting("MAX_PAGES_SETTING", default=5, getter="getint")
+    lang: str = "en"
+
+
+class S(Args[Params], Spider):
+    name = "s"
+
+
+def test_fromsetting_reads_setting():
+    crawler = get_crawler(S, settings_dict={"MAX_PAGES_SETTING": 10})
+    s = S()
+    s._set_crawler(crawler)
+    assert s.args.pages == 10
+    assert s.args.lang == "en"
+
+
+def test_fromsetting_uses_default_when_missing():
+    crawler = get_crawler(S, settings_dict={})
+    s = S()
+    s._set_crawler(crawler)
+    assert s.args.pages == 5
+    assert s.args.lang == "en"
+
+
+def test_cli_overrides_everything():
+    crawler = get_crawler(S, settings_dict={"MAX_PAGES_SETTING": 10})
+    s = S(pages=99)
+    s._set_crawler(crawler)
+    assert s.args.pages == 99


### PR DESCRIPTION
This change introduces FromSetting, a marker that allows spider parameters to declare defaults pulled directly from crawler.settings.
Defaults are resolved in _set_crawler following this precedence:

- Values passed via CLI/kwargs (-a)
- Literal defaults defined in the Pydantic model
- Values from Scrapy settings using FromSetting (with the chosen getter)
- Explicit default provided in FromSetting if the setting is missing
- Validation error if none of the above apply

Unit tests were added to ensure correct precedence and proper integration with Scrapy settings.